### PR TITLE
Tweak style for \trivia command

### DIFF
--- a/src/mystyle.sty
+++ b/src/mystyle.sty
@@ -60,7 +60,7 @@
 \newcommand{\bu}[1]{\textbf{\underline{#1}}}
 %fancyvrb to make verbatim box with colors
 
-\newcommand{\trivia}[1]{\bu{Trivia :} #1}
+\newcommand{\trivia}[1]{\bu{Trivia} : #1}
 
 %for histograms
 \usepackage{pgfplots}


### PR DESCRIPTION
This removes the underline from the : so that it only appears under the word "Trivia".