### PR TITLE
More tweaks to NeXT chapter.

### DIFF
--- a/src/next.tex
+++ b/src/next.tex
@@ -5,17 +5,17 @@
 \includegraphics[width=.20\textwidth]{drawings/NeXT_logo.pdf}
 \end{wrapfigure}
 \par
-NeXT's history starts (and amusingly, also ends) at Apple. In May of 1985, the mediocre sales of the Macintosh drew a bleak future for the company. Steve Jobs, co-founder and then General Manager of the Mac department, wanted to lower the price and increase marketing in order to boost the Mac. John Sculley then CEO, wanted to abandon the Mac and refocus the company resources on the Apple II, the only profitable product Apple had marketed until then.\\
+NeXT's history starts (and amusingly, also ends) at Apple. In May of 1985, the mediocre sales of the Macintosh painted a bleak future for the company. Steve Jobs, co-founder and then General Manager of the Mac department, wanted to lower the price and increase marketing in order to boost the Mac. John Sculley then CEO, wanted to abandon the Mac and refocus the company's resources on the Apple II, the only profitable product Apple had marketed until then.\\
 \par
  A vote was called and the board of directors sided with Sculley. Steve Jobs found himself stripped of all responsibilities. A few months later, on September 13, 1985, he resigned and went on to work on his next project.\\
 \par
-NeXT, Inc was incorporated in February 1986 with \$7 million of Jobs' own money. Many members of the Mac division left Apple to join the newly formed company, among them  Joanna Hoffman, Bud Tribble (head of software division), George Crow, Rich Page, Susan Barnes, Susan Kare, and Dan'l Lewin.\\ 
+NeXT, Inc. was incorporated in February 1986 with \$7 million of Jobs' own money. Many members of the Mac division left Apple to join the newly formed company, among them  Joanna Hoffman, Bud Tribble (head of software division), George Crow, Rich Page, Susan Barnes, Susan Kare, and Dan'l Lewin.\\ 
 \par
 With NeXT, Jobs went back to a project he had contemplated for Apple in August 1985. While touring universities to boost Mac sales, he had met Paul Berg, a Nobel Laureate in chemistry. Paul was frustrated with the cost\footnote{\$100,000.} of teaching students about recombinant DNA in wet laboratories. It would have been cheaper to simulate them. It seemed there was a market for 3M\footnote{One Megabyte of RAM, a Megapixel display and MegaFLOP performance.} workstations targeted at universities and students\footnote{The Second Coming of Steve Jobs.}. NeXT set itself to build something powerful yet cheap enough that college students could afford it.\\
 \par
 \fq{I want some kid at Stanford to be able to cure cancer in his dorm room.}{Steve Jobs, 1987}\\
 \par
-Steve Jobs spared no expenses. For \$100,000, Paul Rand was commissioned with a logo. An automated factory featuring automated surface-mount motherboard assembly\footnote{Source: "The Machine to Build The Machines" mini documentary.} capable of producing 10,000 units per month was built in Fremont, CA. The design firm Frogdesign which had proven itself with the Apple IIc was hired. The goal was to ship by the end of 1986.\\
+Steve Jobs spared no expenses. For \$100,000, Paul Rand was commissioned with a logo. An automated factory featuring automated surface-mount motherboard assembly\footnote{Source: "The Machine to Build The Machines" mini documentary.} capable of producing 10,000 units per month was built in Fremont, CA. The design firm Frogdesign, which had proven itself with the Apple IIc, was hired. The goal was to ship by the end of 1986.\\
 \par
 The machine was to be perfect, following Alan Kay's concept of creating both the hardware and the software to run it.\\
 \par
@@ -35,12 +35,12 @@ Using their experience from Apple and particularly their work on the Macintosh, 
 \section{The NeXT Computer}
 The first machine shipped in 1989 after three years of hard work. Not meeting the initial release target was not a problem according to Jobs who famously replied to a journalist inquiring about the delay: "Late? This computer is five years ahead of its time!".\\
 \par
-Based on a Motorola 68030 25 Mhz with 8 MiB RAM and featuring powerful co-processors such a DSP and a FPU, the high-performance hardware delivered. The machine also happened to be gorgeous. In an era where most computer cases were made of beige plastic, the elegance of the one foot perfect cube made of painted magnesium stood out.\\
+Based on a Motorola 68030 25 Mhz with 8 MiB RAM and featuring powerful co-processors such a DSP and an FPU, the high-performance hardware delivered. The machine also happened to be gorgeous. In an era where most computer cases were made of beige plastic, the elegance of the one foot perfect cube made of painted magnesium stood out.\\
 \par
 \cfullimage{NEXT_Cube}{The Next Computer}
 
 
-The monitor was a piece of art itself. The 17" MegaDisplay allowed a high\footnote{At the time, a 14" monitor delivering a resolution of 640x480 was high-end standard on PC.} resolution of 1120 x 832 pixels with a density of 92 DPI. The Cube's 256 KiB of VRAM allowed four shades of gray per pixel. At launch the supply chain was so tight that when ordering a NeXTComputer, the customer received two parcels. One from Fremont containing the Central Unit and another one  other one directly from Sony containing the MegaDisplay.
+The monitor was a piece of art itself. The 17" MegaDisplay allowed a high\footnote{At the time, a 14" monitor delivering a resolution of 640x480 was high-end standard on PC.} resolution of 1120 x 832 pixels with a density of 92 DPI. The Cube's 256 KiB of VRAM allowed four shades of gray per pixel. At launch the supply chain was so tight that when ordering a NeXT Computer, the customer received two parcels -- one from Fremont containing the central unit, and another directly from Sony containing the MegaDisplay.
 
 
 
@@ -51,12 +51,12 @@ The monitor was a piece of art itself. The 17" MegaDisplay allowed a high\footno
 \cscaledimage{1}{68030_blueprint.png}{Motorola 68030}
 \end{figure}
 \par
-One of the many innovations of the NextComputer was its reliance on the 256 MiB Magneto Optical Drive, a hybrid between HDD and floppy disk aimed at filling both use cases. According to Steve Jobs, it was supposed to allow users to "take their whole world in their backpacks".\\
+One of the many innovations of the NeXT Computer was its reliance on the 256 MiB magneto-optical drive, a hybrid between a HDD and floppy disk aimed at filling both use cases. According to Steve Jobs, it was supposed to allow users to "take their whole world in their backpacks".\\
 % Released in 1987
 \par
-At the heart of the machine, the 32-bit 68030 was the latest in Motorola's 68000 series. A choice likely influenced by the experience NeXT hardware engineers had built while working on Apple's Macintosh and Lisa (both were powered by a 68000).\\
+At the heart of the machine, the 32-bit 68030 was the latest in Motorola's 68000 series. The choice was likely influenced by the experience NeXT hardware engineers had built while working on Apple's Macintosh and Lisa (both were powered by a 68000).\\
 \par
- Running at a frequency of 25Mhz, it was able to generate nearly 5 MIPS. It did not feature a built-in FPU so a Motorola 68882 was placed next to the CPU on the motherboard. %\footnote{Of course, Motorola documentation claimed almost double that with 12 Mips!}
+ Running at a frequency of 25Mhz, it was able to execute nearly 5 MIPS. It did not feature a built-in FPU, so a Motorola 68882 was placed next to the CPU on the motherboard. %\footnote{Of course, Motorola documentation claimed almost double that with 12 Mips!}
 
 
 
@@ -66,9 +66,9 @@ At the heart of the machine, the 32-bit 68030 was the latest in Motorola's 68000
 \end{figure}
 \par
 \vspace{-3mm}
-Above, the 273,000 transistors of the 68030 made of \circled{1} Memory Management Unit, \circled{2} $\mu$ROM, \circled{3} nROM, \circled{4} Control Section, \circled{5} Inst Pipe, \circled{6} Program Counter Execution Unit, \circled{7} Address Execution Unit, \circled{8} Data Execution Unit, \circled{9} 256 bytes i-cache, \circled{A} 256 bytes d-cache, \circled{B} Clock Generator.\\         
+Above, the 273,000 transistors of the 68030, made up of \circled{1} Memory Management Unit, \circled{2} $\mu$ROM, \circled{3} nROM, \circled{4} Control Section, \circled{5} Inst Pipe, \circled{6} Program Counter Execution Unit, \circled{7} Address Execution Unit, \circled{8} Data Execution Unit, \circled{9} 256 bytes i-cache, \circled{A} 256 bytes d-cache, \circled{B} Clock Generator.\\         
 \par
-It is unclear how much of a performance boost the two caches provided. Their small size of 256 bytes each would have incurred a significant cache miss (Intel had discarded its on-die cache from their 386 for this very reason). Interestingly, the designer decided to use both micro-code and nano-code. Sixteen general purpose registers were available which is pretty common for a RISC architecture where load and store have to be done manually\footnote{Intel's CISC based 486 had eight.}.
+It is unclear how much of a performance boost the two caches provided. Their small size of 256 bytes each would have meant a significant cache miss rate (Intel had discarded its on-die cache from their 386 for this very reason). Interestingly, the designer decided to use both micro-code and nano-code. Sixteen general-purpose registers were available which is pretty common for a RISC architecture where load and store have to be done manually\footnote{Intel's CISC-based 486 had eight.}.
 \pagebreak
  
 
@@ -79,20 +79,20 @@ It is unclear how much of a performance boost the two caches provided. Their sma
 \end{wrapfigure}
 
 
-Contrary to PCs which were a mess of wires, the NeXT computers formed a chain. The mouse was connected to the keyboard, itself connected to the screen, connected to the Cube.\\
+Contrary to PCs which were a mess of wires, the NeXT Computers formed a chain. The mouse was connected to the keyboard, itself connected to the screen, connected to the Cube.\\
 
 
 \par
 
 
-If initially the NeXTComputer was acclaimed for its specs, there was a serious issue with the price. Market studies showed that students and researchers wanted a workstation priced at \$3,000. The NeXT Computer started at more than twice the ideal price at \$6,500. To make it worse, the optical drive which powered the basic configuration would turn out to be great for backup but way too slow for runtime. Not only it was noisy and unreliable, it offered an access time of 90 ms, it was 10 times slower than a hard-drive and made the operating system crawl. This rendered the "optional" \$3,500 330 MiB SCSI hard-drive an absolute necessity which pushed the final price tag to \$10,000! A big price to pay for machine not even able to output color.\\
+If initially the NeXT Computer was acclaimed for its specs, there was a serious issue with the price. Market studies showed that students and researchers wanted a workstation priced at \$3,000. The NeXT Computer started at more than twice the ideal price at \$6,500. To make it worse, the optical drive that powered the basic configuration would turn out to be great for backup but way too slow for runtime. Not only it was noisy and unreliable, it offered an access time of 90 ms, 10 times slower than a hard-drive and made the operating system crawl. This rendered the "optional" \$3,500 330 MiB SCSI hard-drive an absolute necessity, pushing the final price tag to \$10,000! A big price to pay for machine not even able to output color.\\
 \par
 
 
 
 
 \section{Line of Products}
-Given the low sales of the NeXT Computer, the original machine was discontinued and the line of products refreshed. In 1991 NeXT released four new products\footnote{Announced four months in advance on September 18, 1990.}. The NextCube which was the direct successor to the NextComputer. A smaller, flattened version of the NeXTCube called the NeXTStation which offered built-in color capability but no expansion slots. Last but not least, a graphic and video processor expansion board called NeXTDimension.\\
+Given the low sales of the NeXT Computer, the original machine was discontinued and the line of products refreshed. In 1991 NeXT released four new products\footnote{Announced four months in advance on September 18, 1990.}. The NeXTcube was the direct successor to the NeXT Computer. A smaller, flattened version of the NeXTcube called the NeXTstation offered built-in color capability but no expansion slots. Last but not least, there was a graphic and video processor expansion board called NeXTdimension.\\
 \par
 \newcolumntype{L}[1]{>{\hsize=#1\hsize\raggedright\arraybackslash}X}%
 \newcolumntype{R}[1]{>{\hsize=#1\hsize\raggedleft\arraybackslash}X}%
@@ -102,25 +102,25 @@ Given the low sales of the NeXT Computer, the original machine was discontinued 
   \toprule
   \textbf{Name} &  \textbf{Year} & \textbf{CPU} & \textbf{Price} & \textbf{in 2018}   \\
   \toprule 
-   NeXTComputer           & 1989 & 68030 25 Mhz & \$6,500 & \$12,938 \\
+   NeXT Computer           & 1989 & 68030 25 Mhz & \$6,500 & \$12,938 \\
 \toprule 
-   NeXTStation             & 1991 & 68040 25 Mhz & \$4,995 & \$9,157 \\
-   NeXTCube                & 1991 & 68040 25 Mhz & \$12 395 & \$21,171 \\
-   NeXTDimension           & 1991 & i860  33 Mhz & \$3,995 & \$7,552 \\
-   NeXTStation Color       & 1991 & 68040 25 Mhz & \$7,995 & \$14,656 \\
+   NeXTstation             & 1991 & 68040 25 Mhz & \$4,995 & \$9,157 \\
+   NeXTcube                & 1991 & 68040 25 Mhz & \$12 395 & \$21,171 \\
+   NeXTdimension           & 1991 & i860  33 Mhz & \$3,995 & \$7,552 \\
+   NeXTstation Color       & 1991 & 68040 25 Mhz & \$7,995 & \$14,656 \\
 \toprule 
-   NeXTCube Turbo          & 1992 & 68040 33 Mhz & \$10,000 & \$18,121 \\
-   NeXTStation Turbo       & 1992 & 68040 33 Mhz & \$5995 & \$11,932 \\
+   NeXTcube Turbo          & 1992 & 68040 33 Mhz & \$10,000 & \$18,121 \\
+   NeXTstation Turbo       & 1992 & 68040 33 Mhz & \$5995 & \$11,932 \\
    
-   NeXTStation Turbo Color & 1992 & 68040 33 Mhz & \$8995 & \$17,904 \\
+   NeXTstation Turbo Color & 1992 & 68040 33 Mhz & \$8995 & \$17,904 \\
    \toprule
 \end{tabularx}
-\caption{\protect\NeXT products from 1985 to 1993\protect\footnotemark.}
+\caption{\protect\NeXT products from 1989 to 1993\protect\footnotemark.}
 \end{figure}
 \par
 \footnotetext{Source: kevra.org (Competing Hardware Comparisons), https://simson.net/ref/NeXT/specifications.htm, and "The Second Coming of Steve Jobs".}
 \par
-In 1992, they buffed up their entire line with Turbo version and what would become the Gold Standard at id Software: The NeXTStation Color Turbo.
+In 1992, they buffed up their entire line with the Turbo version and what would become the Gold Standard at id Software: The NeXTstation Color Turbo.
 
 
 
@@ -131,41 +131,41 @@ In 1992, they buffed up their entire line with Turbo version and what would beco
 
 
 \section{NeXTCube}
-From the outside the NextCube 12" cube central unit looked exactly like its predecessor the NeXTComputer. However the inside told a different story.\\
+From the outside the NeXTcube's 12" cubic central unit looked exactly like its predecessor the NeXT Computer. However, the inside told a different story.\\
 \par
- The CPU was bumped to a Motorola 68040 25Mhz, a chip capable of three times the 68030's throughput with 15 MIPS\footnote{Source: "Fast New Systems from NeXT", B.Y.T.E Nov 1990}. The machine's RAM capacity was doubled with an out of factory 16 MiB, extensible to 64 MiB. The magneto optical disc was abandoned in favor of an HDD, a floppy disk reader, and an optional CD-ROM drive. The HDD capacity was augmented with a choice of 400 MB, 1.4GB or 2.8GB SCSI drive. The floppy disks were twice the capacity of PCs at 2.88 MB. The CD-ROM was built-in the magnesium case.\\
+ The CPU was bumped to a Motorola 68040 25Mhz, a chip capable of three times the 68030's throughput with 15 MIPS\footnote{Source: "Fast New Systems from NeXT", B.Y.T.E Nov 1990}. The machine's RAM capacity was doubled, with an out of factory 16 MiB, expandable to 64 MiB. The magneto-optical disc was abandoned in favor of a HDD, floppy disk reader, and an optional CD-ROM drive. The HDD capacity was augmented with a choice of 400 MB, 1.4GB or 2.8GB SCSI drive. The floppy disks were twice the capacity of PCs at 2.88 MB. The CD-ROM was built into the magnesium case.\\
 \par
 \begin{minipage}{\textwidth}
 \scaledimage{0.5}{next/next-crt-top.png} \scaledimage{0.5}{next/next-cube-top.png}\\
 \end{minipage}
 
 \par
-The NextCube Turbo released in 1992 was almost the same machine except the 68040's frequency was bumped to 33 Mhz and the max RAM capacity increased to 128 MiB.\\
+The NeXTcube Turbo released in 1992 was almost the same machine, except the 68040's frequency was bumped to 33 MHz and the max RAM capacity increased to 128 MiB.\\
 \par
-The standard and turbo versions' only weakness remained the video. Shipping with 256 KiB of VRAM the machine could only output four colors (white, black and two shades of gray). To bring color to the NextCube, customers had to invest in a NeXTDimension board.\\
+The standard and turbo versions' only weakness remained the video. Shipping with 256 KiB of VRAM, the machine could only output four colors (white, black and two shades of gray). To bring color to the NeXTcube, customers had to invest in a NeXTdimension board.\\
 \par
 
-\trivia{The NeXTCube Turbo extension slot could welcome a Nitro board which replaced the 68040 33Mhz with a 68040 40 Mhz. Only 10 Nitro boards are known to exist, they are extremely rare and highly sought after by collectors.}
+\trivia{The NeXTcube Turbo expansion slot could welcome a Nitro board that replaced the 68040 33Mhz with a 68040 40 Mhz. Only 10 Nitro boards are known to exist, they are extremely rare and highly sought after by collectors.}
 \pagebreak
 
 
-\cfullimage{next/NeXTcube_motherboard.png}{NextCube motherboard}
+\cfullimage{next/NeXTcube_motherboard.png}{NeXTcube motherboard}
 \par
-Opening the machine revealed the minutiae NeXT had adopted as its standard. The NeXT Cube motherboard above shows that aesthetics were not sacrificed for performance. Surface Mounting allowed components to be placed much closer to others than usual.\\
+Opening the machine revealed the minutiae NeXT had adopted as its standard. The NeXTcube motherboard above shows that aesthetics were not sacrificed for performance. Surface mounting allowed components to be placed much closer to others than usual.\\
 \par
-Hidden under a heat-sink\footnote{Heat dissipation was always a problem for the 68040 which prevented high frequencies, a handicap against Intel's 486 capable of 66 Mhz.}, packing 1.2 millions transistors, the CPU was a big step up. The Harvard architecture (separated storage and signal pathways for instructions and data), write-back capability, 8 KiB cache (4 KiB data and 4 KiB instructions), and an integrated FPU tripled throughput compared to the 68030.
+Hidden under a heat-sink\footnote{Heat dissipation was always a problem for the 68040 which prevented running at high frequencies, a handicap against Intel's 486 capable of 66 Mhz.} and packing 1.2 million transistors, the CPU was a big step up. The Harvard architecture (separated storage and signal pathways for instructions and data), write-back capability, 8 KiB cache (4 KiB data and 4 KiB instructions), and integrated FPU tripled throughput compared to the 68030.
 
 
 
 
 
 \vspace{50 mm}
-\drawing{NeXTCube_motherboard}{NeXTCube motherboard diagram}
+\drawing{NeXTCube_motherboard}{NeXTcube motherboard diagram}
 \par
-Chipsets and components of the NeXTCube motherboard:\\
+Chipsets and components of the NeXTcube motherboard:\\
 \par 
 \circled{1} NeXTBus connector,
-\circled{2} VLSI NeXTbus Interface Chip,
+\circled{2} VLSI NeXTBus Interface Chip,
 \circled{3} CPU Motorola 68040,
 \circled{4} 256~KiB~VRAM,
 \circled{5} DRAM Controller CS38PG017CG01,
@@ -174,7 +174,7 @@ Chipsets and components of the NeXTCube motherboard:\\
 \circled{8} 16 SIMM slots max 4MiB each for total 64 MiB,
 \circled{9} DSP-56001RC20,
 \circled{A} Battery,
-\circled{B} NeXT Prom BIOS,
+\circled{B} NeXT BIOS PROM,
 \circled{C} DSP 768K Slot,
 \circled{D} Hard-Drive and Floppy connectors.
 \circled{E} Many connectors (top to bottom): 56001 DSP, Serial Port A\&B, SCSI2, Printer, Ethernet RJ45\&CoaxBNC, DB19 Monitor. 
@@ -188,30 +188,30 @@ Chipsets and components of the NeXTCube motherboard:\\
 
 
 
-\section{NeXTStation}
+\section{NeXTstation}
 
-Since cost was the main issue with their product line, NeXT attempted to introduce a less expensive product. They designed something close to the NeXTCube but removed non essential elements in order to produce a three times cheaper, all-in-one machine.\\
+Since cost was the main issue with their product line, NeXT attempted to introduce a less expensive product. They designed something close to the NeXTcube but removed non essential elements in order to produce a three times cheaper, all-in-one machine.\\
 \par
-The NeXTStation pricing and appearance make it a direct competitor of SPARCstation. No longer a perfect cube, the case nicknamed "the slab" (and also, banned by Steve Jobs, the "pizza box") was well received by customers and became \NeXTns{}'s most successful computer.\\
+The NeXTstation's pricing and appearance made it a direct competitor to the SPARCstation. No longer a perfect cube, the case, nicknamed "the slab" (and also, banned by Steve Jobs, the "pizza box") was well-received by customers and became \NeXTns{}'s most successful computer.\\
 \par 
-\cfullimage{cube_vs_slab.png}{A NextStation ad from NeXTWorld 1991 magazine.}
+\cfullimage{cube_vs_slab.png}{A NeXTstation ad from NeXTWorld 1991 magazine.}
 \par
 \vspace{-10pt}
-Designers picked elements from the NextCube and the NeXTDimension in order to produce an all-in-on, non extensible machine. The three NeXTBUS extension slots were removed and so was the CD-ROM. A 2.88MiB floppy disk was added on the right side. The most notable difference came from the Color version which had 2 MiB of VRAM, making the machine capable of 16-bit RGB colors. To accommodate for the increased bandwidth requirements, the motherboard was redesigned to include a Bt463 RAMDAC.\\
+Designers picked elements from the NeXTcube and the NeXTdimension in order to produce an all-in-one, non extensible machine. The three NeXTBus expansion slots were removed and so was the CD-ROM. A 2.88MiB floppy disk was added on the right side. The most notable difference came in the color version that had 2 MiB of VRAM, making the machine capable of 16-bit RGB colors. To accommodate the increased bandwidth requirements, the motherboard was redesigned to include a Bt463 RAMDAC.\\
 \par
 % The system also introduced usage of the Apple Desktop Bus created by Steve Wozniak which bear many similarities with the USB released in 1996. With ADB, input devices such as mouse and keyboard are connected as a daisy chain\footnote{ADB - The Untold Story: Space Aliens Ate My Mouse.} and can be plugged/unplugged safely while the machine was powered on without fearing to fry something.\\
 \fq{The 16-bit color was only 4444, 1555 was not supported, which was unfortunate for us.  It was also in a linear color space\footnotemark, as opposed to the non-linear PC standard that became sRGB.  I didn't understand how to properly convert back then, so our graphics always looked washed out on the NeXT systems.}{John Carmack}\footnotetext{NeXT, SGI, and Apple had linear color space. PC of course did not.}
 
 
 
-\cfullimage{next/nextstation.png}{A NeXTStation Turbo Color (non-ADB)}
+\cfullimage{next/nextstation.png}{A NeXTstation Turbo Color (non-ADB)}
 \par
 \vspace{-5pt}
-In an unmistakable Steve Jobsian rhetoric, several components were renamed to emphasis subtle differences. The central unit fan was called a "whisper fan"\footnote{Source: "Fast New Systems from NeXT", B.Y.T.E Nov 1990}.  The power supply was a 120-watt unit using a new technology called "parallel resonant switching" which allegedly allowed a much smaller form factor than conventional power supplies.\\
+In an unmistakable Steve Jobsian fashion, several components were renamed to emphasize subtle differences. The central unit fan was called a "whisper fan"\footnote{Source: "Fast New Systems from NeXT", B.Y.T.E Nov 1990}.  The power supply was a 120-watt unit using a new technology called "parallel resonant switching" that allegedly allowed a much smaller form factor than conventional power supplies.\\
 \par
-Despite its reduced size, the NeXStation's performance did not suffer compared to the more imposing NeXTCube. The three variants, NeXTStation, NeXTStation Color, and NeXTStation Turbo Color all relied on the 68040 and shipped with 12 MiB of RAM.\\
+Despite its reduced size, the NeXTstation's performance did not suffer compared to the more imposing NeXTcube. The three variants -- NeXTstation, NeXTstation Color, and NeXTstation Turbo Color -- all relied on the 68040 and shipped with 12 MiB of RAM.\\
 \par
-\trivia{Notice in the picture that no button or switch are visible on the computer itself. The machine could only be turned on and off via the keyboard (a novelty at the time). An update later introduced the Apple Desktop Bus created by Steve Wozniak which bears many similarities to the USB released in 1996.}
+\trivia{Notice in the picture that no button or switch are visible on the computer itself. The machine could only be turned on and off via the keyboard (a novelty at the time). An update later introduced the Apple Desktop Bus created by Steve Wozniak which bears many similarities to the USB standard released in 1996.}
 \pagebreak
 
 
@@ -222,27 +222,27 @@ Despite its reduced size, the NeXStation's performance did not suffer compared t
 
 
 
-\section{NeXTDimension}
+\section{NeXTdimension}
 \vspace{-3pt}
-The 256 KiB of VRAM on the NeXTCube only allowed a mediocre four shades of gray. The NeXTDimension was to take the workstation to a whole new level. Shipping with 4 MiB of RAM (extensible to 32 MiB), it allowed 24-bit color per pixel GUI and realtime recording/playback of video signals. Since the board was connected via a NeXTBus port, up to three NeXTDimensions could be connected, allowing the NeXTCube to drive four extended screens simultaneously.\\
+The 256 KiB of VRAM on the NeXTcube only allowed a mediocre four shades of gray. The NeXTdimension was to take the workstation to a whole new level. Shipping with 4 MiB of RAM (extensible to 32 MiB), it allowed a 24-bit color per pixel GUI and real-time recording/playback of video signals. Since the board was connected via a NeXTBus port, up to three NeXTdimensions could be connected, allowing the NeXTcube to drive four extended screens simultaneously.\\
 \par
-On presentation day Steve Jobs managed to demonstrate the groundbreaking capabilities in his signature spectacular fashion. A run from the black and white movie Alice in Wonderland movie was played live on a NextCube, already a tour de force at the time. The audience was impressed yet the best was to come. As Alice progressed through Wonderland, frames progressively turned to color. The audience went berserk.\\
+On presentation day, Steve Jobs managed to demonstrate the groundbreaking capabilities in his signature spectacular fashion. A sequence from the black-and-white movie Alice in Wonderland was played live on a NeXTcube, already a tour-de-force at the time. The audience was impressed yet the best was to come. As Alice progressed through Wonderland, frames progressively turned to color. The audience went berserk.\\
 \par
-At some point the NextDimension was even planned to feature real-time video compression but problems prevented it.\\
+At some point the NeXTdimension was even planned to feature real-time video compression, but problems prevented it.\\
 \par
 \fq{NeXT has eliminated the C-Cube Microsystems CL-550 JPEG chip from NeXTdimension. This is because our supplier, C-Cube Microsystems, has failed to deliver chips that meet their specifications.}{Felipe\_Fuster\at NeXT.COM}\\
 \par
-The NeXTDimension was not a mere extension board, it was full featured computer within the computer. It had its own operating system, RAM, and clock generator which communicated with NeXTStep via Mach messages.\\
+The NeXTdimension was not a mere expansion board, but rather a full-featured computer within the computer. It had its own operating system, RAM, and clock generator which communicated with NeXTSTEP via Mach messages.\\
 \par
 \fq{The NeXTdimension ran a custom kernel which was designed to do soft real-time management of multiple threads within a single address space, provide demand paged virtual memory, and provide a source-compatible Mach API subset and full Mach messaging interface, along with a minimal UNIX system call API, just enough to implement the RenderMan back end and the PostScript device layer. The kernel was called "Graphics aCcelerator Kernel, or "GaCK". Yes, this was a jape at the funny capitalization of the company name. It was not Mach, or BSD, or Minix, or Linux.}{M Paquette}
 \par
 \par
-The card came with \cw{NeXTtv.app} which allowed video editing and frame capture.
+The card came with the \cw{NeXTtv.app} which allowed video editing and frame capture.
 \par
 \vspace{5pt}
 \fullimage{NeXTtv.png}
 \par
-Because of Steve Jobs's "hobby" venture with Pixar, the NeXTDimension had close ties with RenderMan. It had a built-in hardware acceleration module called Quick RenderMan.\\
+Because of Steve Jobs's "hobby" venture with Pixar, the NeXTdimension had close ties with RenderMan. It had a built-in hardware acceleration module called Quick RenderMan.\\
 \par
 % Renderman uses a similar architecture. The 3DKit and RI C binding reside on the m68k (otherwise you couldn't link with them). 
 \fq{
@@ -254,16 +254,16 @@ Depending on the setup of the Renderman context, a RIB stream can be spooled to 
 
 
 
-\cfullimage{next/NextDimension_board.png}{NeXTDimension board}
+\cfullimage{next/NextDimension_board.png}{NeXTdimension board}
 \par
-Like the NextCube and NextStation motherboards, the NeXTDimension hardware was gorgeous and benefited from the same "Surface Mounting" manufacturing process. The most prominent component is of course the Intel 840.\\
-\par It had failed to beat Intel's 486 CPU in the market but its eagerness to participate to \doom{} phenomenon allowed it to land a gig on the tool team.\\
+Like the NeXTcube and NeXTstation motherboards, the NeXTdimension hardware was gorgeous and benefited from the same "surface mount" manufacturing process. The most prominent component is of course the Intel 840.\\
+\par It had failed to beat Intel's 486 CPU in the market but its eagerness to participate in the \doom{} phenomenon allowed it to land a gig on the tools team.\\
 \par
-\trivia{Notice the Bt463 RAMDAC which would also be used on NeXTStations.}
+\trivia{Notice the Bt463 RAMDAC which would also be used on NeXTstations.}
 \par
-\drawing{NeXTDimension_motherboard}{NeXTDimension board diagram}
+\drawing{NeXTDimension_motherboard}{NeXTdimension board diagram}
 \par
-List of chipsets and components of the NextDimension motherboard:\\
+List of chipsets and components of the NeXTdimension motherboard:\\
 \par 
 \circled{1} NeXTBus connector,
 \circled{2} VLSI NeXTBus Interface Chip (NBIC),
@@ -279,13 +279,13 @@ List of chipsets and components of the NextDimension motherboard:\\
 \circled{C} 100.000Mhz Oscillator K1149AA
 \par
 
-\cfullimage{NeXTDimension.png}{An early NeXTDimension ad from NeXT Magazine 1991.}
+\cfullimage{NeXTDimension.png}{An early NeXTdimension ad from NeXT Magazine 1991.}
 \par
-Notice the C-Cube Microsystems JPEG chip which had to be cut from the final design and the different resin used resulting in a different color for the motherboard. No doubt the color tone was the subject of many debates at NeXT headquarters. The "unlucky forever" Intel i860 was mislabeled "1860".
+Notice the C-Cube Microsystems JPEG chip which had to be cut from the final design, and the different resin, resulting in a different color for the motherboard. No doubt the color tone was the subject of many debates at NeXT headquarters. The "unlucky forever" Intel i860 was mislabeled "1860".
 \pagebreak
 
 
-To select the i860 as the main chip of a graphic card could have been called overkill but it was a careful and ultimately sound decision. Video processing is an intensive CPU task. It benefits so much from the i860's SIMD pipeline that nothing else but Intel's "Cray on a Chip" could have done the job.\\
+To select the i860 as the main chip for a graphics card could have been called overkill but it was a careful and ultimately sound decision. Video processing is an intensive CPU task. It benefits so much from the i860's SIMD pipeline that nothing else but Intel's "Cray on a Chip" could have done the job.\\
 \par
 \fq{
 The Intel 80860 was an impressive chip, able at top speed to perform close to 66 MFLOPS at 33 MHz in real applications, compared to a more typical 5 or 10 MFLOPS for other CPUs of the time. Much of this was marketing hype, and it never become popular, lagging behind most newer CPUs and Digital Signal Processors in performance.
@@ -311,8 +311,8 @@ However actually getting the chip at top speed usually requires using assembly l
 
 
 
-\section{NeXTStep}
-  NeXT's 1990 24-pages brochure "Welcome to the NeXT decade" introducing NeXT Computer System, laid out the seven pillars of the  system they were about to build.\\
+\section{NeXTSTEP}
+  NeXT's 1990 24-pages brochure, "Welcome to the NeXT decade" introducing the NeXT Computer System, laid out the seven pillars of the system they were about to build.\\
 \par
 \rawfq{
  Our collaboration with Higher Education provided the insight needed to visualize the seven breakthroughs that would ultimately define the NeXT Computer:\\
@@ -333,38 +333,38 @@ However actually getting the chip at top speed usually requires using assembly l
 
 The first three points were the hardware team's responsibility. Everything else was on the software team and the amount of work ahead of them was overwhelming. The magical operating system described did not exist in '86. To deliver their vision, they had to build it.\\
 \par
- To create an OS from scratch would have been an humongous effort. To save time the software team decided to reuse available components. They selected a micro kernel called Mach from Carnegie Mellon University and combined it with BSD (from University of California, Berkeley) elements such a network stack, multi-user, multi-process and file-system. That was enough to bring the machine up to a command prompt.
+ To create an OS from scratch would have been a humongous effort. To save time, the software team decided to reuse available components. They selected a microkernel called Mach from Carnegie Mellon University and combined it with elements from BSD (from University of California, Berkeley), such as the network stack, multi-user, multi-processing and filesystem. That was enough to bring the machine up to a command prompt.
 \par
 \subsection{GUI}
- To achieve the "unified imaging system", \NeXT engineers started from the language designed by Adobe for high-end printers, PostScript and modified it to meet the need of a GUI in terms of look and feel, and performance. The result was called Display PostScript\footnote{When OpenStep was used to build Rhapsody at Apple, the display system was changed to Portable Document Format (PDF) imaging model.}.\\
+ To achieve the "unified imaging system", \NeXT engineers started from PostScript -- the language designed by Adobe for high-end printers -- and modified it to meet the need of a GUI in terms of look-and-feel and performance. The result was called Display PostScript\footnote{When OpenSTEP was used to build Rhapsody at Apple, the display system was changed to Portable Document Format (PDF) imaging model.}.\\
 \par
-\cfullimage{next/nextstep.png}{NextStep 1.0 running on a NeXTComputer in four color mode.}
+\cfullimage{next/nextstep.png}{NeXTSTEP 1.0 running on a NeXT Computer in four color mode.}
 \par
-The resulting graphic system had many impressive features.\\
+The resulting graphical system had many impressive features.\\
 \par
- While some were raw power accomplishments like for example the ability to see the content of a window while moving it (on all competing GUI based OSes, windows had to be moved with only the outline visible because of graphic card and bandwidth limitations), some were purely based on superior design and so solid that they reminded in a form or another all the way up to MacOS X running on 2018 Apple computers. The desktop metaphor, the unified titlebar scheme, the Dock, and File Manager column view flow are only the most famous on a long list of GUI innovations.
+ Some were raw power accomplishments, like for example the ability to see the content of a window while moving it (in all competing GUI-based OSes, windows had to be moved with only the outline visible because of graphic card and bandwidth limitations). Others were purely based on superior design and so solid that they remain in one form or another all the way up to Mac OS X running on 2018 Apple computers. The desktop metaphor, the unified titlebar scheme, the Dock, and File Manager column view flow are only the most famous in a long list of GUI innovations.
 
 
 
 
 \fq{The Display PostScript system can be broken into two pieces, the PostScript interpreter and the device. The interpreter processes the language, and passes marking, imaging, and compositing directions to the device layer.\\ 
 \par
-The device layer takes the high level marking, imaging, and compositing operations and (eventually) converts these to bitmap level operations. The Display PostScript system spends the majority of it's time down here. In the case of the NeXTdimension board, the device layer is implemented on the NeXTdimension board. Marking, imaging, and compositing operations are asynchronously transmitted to the NeXTdimension for processing while additional PostScript is interpreted on the 68K processor. A good degree of parallelism is achieved in normal operation.}{M Paquette} 
+The device layer takes the high level marking, imaging, and compositing operations and (eventually) converts these to bitmap level operations. The Display PostScript system spends the majority of its time down here. In the case of the NeXTdimension board, the device layer is implemented on the NeXTdimension board. Marking, imaging, and compositing operations are asynchronously transmitted to the NeXTdimension for processing while additional PostScript is interpreted on the 68K processor. A good degree of parallelism is achieved in normal operation.}{M Paquette} 
 %The NXPing() AppKit call is interpreted by the Display PostScript system as a request to synchronize the NeXTdimension, PostScript interpreter, and app, and will not return until PostScript rendering is complete on the NeXTdimension.
 \par
 %Running on a color capable machine, the GUI was the most beautiful interface of its time.\\ 
 \vspace{5mm} \label{nextstep_color.png}
 % \scaledimage{0.95}{nextstep_color.png} 
-\cfullimage{nextstep_color.png}{NeXTSTEP running on system with a 24-bit NeXTDimension}
+\cfullimage{nextstep_color.png}{NeXTSTEP running on system with a 24-bit NeXTdimension}
 \par
-Figure \ref{nextstep_color.png} shows NeXTSTEP running on a 24-bit colors machine. The composition was more gorgeous than any of its competitors was capable of. Notice \cw{Mail.app} which shipped with an email from Steve Jobs vaunting the merits of Object Oriented Programming.
+Figure \ref{nextstep_color.png} shows NeXTSTEP running on a 24-bit color machine. The composition was more gorgeous than what any of its competitors was capable of. Notice \cw{Mail.app}, which shipped with an email from Steve Jobs lauding the merits of object-oriented programming.
 
 \section{NeXT at id Software}
-To say NeXT computers polarized professionals would be an understatement. It is fair to say that everybody had a strong opinion about them. Some developers hated it.\\
+To say NeXT polarized professionals would be an understatement. It is fair to say that everybody had a strong opinion about them. Some developers hated it.\\
 \par
 \fq{Develop for it? I'll piss on it!}{Bill Gates\footnotemark.}\\
 \par
-Some were interested to have access to a stable Unix system combining a powerful GUI.\\
+Some were interested in having access to a stable Unix system with a powerful GUI.\\
 \par
 \footnotetext{Found in Walter Isaacson's book "Steve Jobs" but with no source. Bill Gates may have never said that.}
 \fq{
@@ -374,16 +374,16 @@ When id Software was stationed in Madison, Wisconsin during the winter of 1991, 
  After his research was done it was agreed that the entire company needed to develop our next game on NeXTSTEP.}{John Romero, rome.ro, December 20, 2006}\\
  \footnotetext{Emptying his bank account in the process.}
 \par
-Given the timing of its purchase, the NeXT was first used to produce Wolfestein3D Hint Book. One of the best DTP application at the time, \cw{FrameMaker.app} proved perfect for the task. After that, NeXT rapidly conquered id Software for all other operations. PCs remained in use mostly for Deluxe Paint and to test the game they wanted to ship.\\
+Given the timing of his purchase, the NeXT was first used to produce the Wolfenstein 3D hint book. One of the best DTP applications at the time, \cw{FrameMaker.app} proved perfect for the task. After that, NeXT rapidly conquered id Software for all other operations. PCs remained in use mostly for Deluxe Paint and to test the game they wanted to ship.\\
 \par
-As the needs of the studio evolved with more and more power, id took advantage of NeXTStep's ability to run on various platforms from HP and Intel (called the "White hardware").
+As the needs of the studio evolved with more and more power, id took advantage of NeXTSTEP's ability to run on various platforms from HP and Intel (called the "White hardware").
 
 
 
 
 
 
-The studio bought so much hardware over the years that twenty five years later, accounts differ on which was the first kind of NeXT machine was purchased. According to John Carmack it was a NeXTStation.\\
+The studio bought so much hardware over the years that twenty-five years later, accounts differ about which was the first kind of NeXT machine was purchased. According to John Carmack it was a NeXTstation.\\
 \par
 \vspace{2mm}
 
@@ -394,7 +394,7 @@ This was all in the context of DOS or Windows 3.x; it was revelatory to have a c
 \par
 Over the entire course of Doom and Quake 1's development we probably spent \$100,000 on NeXT computers, which isn't much at all in the larger scheme of development. We later spent more than that on Unix SMP server systems (first a quad Alpha, then an eventually 16-way SGI system) to run the time consuming lighting and visibility calculations for the Quake series. I remember one year looking at the Top 500 supercomputer list and thinking that if we had expanded our SGI to 32 processors, we would have just snuck in at the bottom.}{John Carmack, quora.com}\\
 \par
-John Romero remembers first buying a monochrome NextCube.\\
+John Romero remembers first buying a monochrome NeXTcube.\\
 \par
 \fq{The NeXTCube was purchased in December 1991 and was the only NeXT Computer we had until December 1992 when we decided we would develop DOOM with them so we bought 3 NeXTStations: mine, John Carmack's new one, Tom Hall's. John C's original NeXTCube was the computer used to scan the clay models, gun toys, and latex models.\\
 \par
@@ -418,19 +418,19 @@ DOOM, DOOM II and Quake weren't the only games developed on NeXTSTEP. When I got
 
 
 \section{Roller coaster}
-During its seven years in business, NeXT lead a tumultuous life. It was sued by Apple within its first month of existence (the five people Steve Jobs had taken with him were not "minor people" as he had told Apple). Carried on by Steve Jobs' "reality distortion field", the company was praised for several years while it yet had to produce anything. Glorified upon each release, owing a lot to marketing genius, the machines later struggled to find customers. Disappointing sales led to a near death experience before NeXT managed to re-invent itself.\\
+During its seven years in business, NeXT lead a tumultuous life. It was sued by Apple within its first month of existence (the five people Steve Jobs had taken with him were not "minor people" as he had told Apple). Carried on by Steve Jobs' "reality distortion field", the company was praised for several years even though it had yet to produce anything. Glorified upon each release, owing a lot to marketing genius, the machines later struggled to find customers. Disappointing sales led to a near death experience before NeXT managed to re-invent itself.\\
 \par
 \vspace{-5pt}
 \subsection{Downfall}
-As elegant and powerful as the black hardware was, their high price tag made them a deal breaker. Even the "cheaper" NeXTStations were well beyond most developer's budget.\\
+As elegant and powerful as the black hardware was, their high price tag made them a dealbreaker. Even the "cheaper" NeXTstations were well beyond most developers' budgets.\\
 \par
- In 1988, the factory was building 400 units/month, well below its maximum 10,000/month capacity. Sales worsened over 1989 with only 360 units/month sold over the year. Production had to be slowed down to 100 units/month to avoid overflowing storage. In 1990 things improved slightly with 28 million in revenue which were still a far cry of the 2,800 millions SUN generated that same year. 1991 saw yet another improvement with 20,000 units sold and a revenue of \$127 millions. That figure was still fewer than what Apple sold in a single week. In 1992, sales reached \$140 millions\footnote{Source:The Next Big Thing.} and NeXT claimed its first profitable quarter\footnote{In fact it was \$40 millions from breaking even. Source: "The Next Big Thing"}, seven years after its creation.\\
+ In 1988, the factory was building 400 units/month, well below its maximum 10,000/month capacity. Sales worsened in 1989 with only 360 units/month sold over the year. Production had to be slowed down to 100 units/month to avoid overflowing storage. By 1990 things improved slightly with \$28 million in revenue -- still a far cry from the 2,800 millions SUN generated that same year. 1991 saw yet another improvement with 20,000 units sold and a revenue of \$127 million. That figure was still less than what Apple sold in a single week. By 1992, sales reached \$140 million\footnote{Source:The Next Big Thing.} and NeXT claimed its first profitable quarter\footnote{In fact it was \$40 million from breaking even. Source: "The Next Big Thing"}, seven years after its founding.\\
 \par
-Despite the steady improvements, NeXT still lost \$40 million that year. With only 50,000 NeXT machines sold over the course of its short life\footnote{In 1993 Apple sold 50,000 units every six days.} (including thousands to the then secret National US Reconnaissance Office), Jobs decided that NeXT as a hardware manufacturer could not carry on. Struggling to close deals and hemorrhaging cash, it fired 300 out of its 500 employee workforce on a Black Tuesday of February 1993 to become a software-only company.\\
+Despite the steady improvements, NeXT still lost \$40 million that year. With only 50,000 NeXT machines sold over the course of its short life\footnote{In 1993 Apple sold 50,000 units every six days.} (including thousands to the then secret National US Reconnaissance Office), Jobs decided that NeXT could not carry on as a hardware manufacturer. Struggling to close deals and hemorrhaging cash, it fired 300 out of its 500 employee workforce on a Black Tuesday of February 1993 to become a software-only company.\\
 \par
- The purpose of NeXTSTEP was changed. From operating system in charge of making the black hardware sing, it was to become a white hardware enabler and the sole money maker. It was re-factored to be portable and capable of runnin on Intel, SPARC, and PA-RISC CPUs. Sold as a combination operating system and object-oriented development environment. NeXTstep for Intel became a popular product among large companies and especially financial institutions for rapidly developing and deploying custom software. NeXT also started to collaborate with Sun Microsystems on a light version of NeXTSTEP called OpenSTEP.\\
+ The purpose of NeXTSTEP changed. From operating system in charge of making the black hardware sing, it was to become a white box hardware enabler and the sole money maker. It was re-factored to be portable and capable of running on Intel, SPARC, and PA-RISC CPUs. It was sold as a combination operating system and object-oriented development environment. NeXTSTEP for Intel became a popular product among large companies and especially financial institutions for rapidly developing and deploying custom software. NeXT also started to collaborate with Sun Microsystems on a light version of NeXTSTEP called OpenSTEP.\\
 
-Even in its darkest hours, NeXT curiously never capitalized on id Software's appreciation for the platform\footnote{comp.sys.next.advocacy: "DOOM: NeXTstep's Most Successful App".}. Reportedly due to Steve Jobs disdain for video games, they even turned down an opportunity which could have helped them tremendously.\\
+Even in its darkest hours, NeXT curiously never capitalized on id Software's appreciation for the platform\footnote{comp.sys.next.advocacy: "DOOM: NeXTstep's Most Successful App".}. Reportedly due to Steve Jobs' disdain for video games, they even turned down an opportunity that could have helped them tremendously.\\
 \par
 
 \fq{We loved our NeXTs, and we wanted to launch Doom with an explicit "Developed on NeXT computers" logo during the startup process\protect\footnotemark, but when we asked, the request was denied.}{John Carmack}\\
@@ -444,9 +444,9 @@ Even in its darkest hours, NeXT curiously never capitalized on id Software's app
 
 
 \subsection{Rebirth}
-The rest of \NeXTns's history has nothing to envy to an Hollywoodian plot-twist. In 1995, Apple Computer's failed attempt at producing its own operating system under project "Copland" had placed the company in a precarious situation with nothing to replace its outdated System 7.\\
+The rest of \NeXTns's history has nothing to envy to a Hollywood plot-twist. In 1995, Apple Computer's failed attempt at producing its own operating system under project "Copland" had placed the company in a precarious situation with nothing to replace its outdated System 7.\\
 \par
- After briefly considering BeOS, Apple elected to buy NeXT in 1996 for \$429 million in cash. The timing could not have been better for \NeXT which was on the verge of bankruptcy. Steve Jobs returned to the company he had co-founded twenty years earlier. After the sale, he first worked as an advisor but was later appointed acting-CEO, to finally become CEO of the company. This was not only a rebirth for \NeXTns, it was also a rebirth for Apple which went from being ninety days away from insolvency\footnote{Source: "All Things Digital conference, Jun 1, 2010."} in 1996 to most valuable company in the world in December 2017. \\
+ After briefly considering BeOS, Apple elected to buy NeXT in 1996 for \$429 million in cash. The timing could not have been better for \NeXT which was on the verge of bankruptcy. Steve Jobs returned to the company he had co-founded twenty years earlier. After the sale, he first worked as an advisor but was later appointed acting-CEO, to finally become CEO of the company. This was not only a rebirth for \NeXTns, it was also a rebirth for Apple, which went from being ninety days away from insolvency\footnote{Source: "All Things Digital conference, Jun 1, 2010."} in 1996 to most valuable company in the world in December 2017. \\
 \par
 NeXTSTEP was used as foundation for Apple's Rhapsody project which became Darwin, the core of Apple's OSes. The new operating system was met with enthusiasm by customers and professionals who praised the design, look and feel, and stability. Darwin was later used as a base for Apple's 2008 iPhone which took the world by storm. It is extremely likely some of the code that once ran on NeXTSTEP and contributed to \doom{} now runs on the many millions of Apple computers and iOS phones across the world.\\
 


### PR DESCRIPTION
As part of this I standardized the capitalization for NeXT products
so that they match the Wikipedia article titles (which I'm assuming
are correct):

* NeXT Computer
* NeXTstation
* NeXTdimension
* NeXTcube
* NeXTSTEP