### PR TITLE
Change to statement about modems on Doom's release

### DIFF
--- a/src/network.tex
+++ b/src/network.tex
@@ -114,7 +114,7 @@ AOL (America OnLine) offered a package of five hours for \$9.95 with each extra 
 
 
 
-Throughout the '90s, bandwidth steadily improved. Upon \doom{}'s release most modems were capable of 28.8 Kbit/s. Those who downloaded the shareware version in December 1993 had to wait 12.5 minutes to retrieve the 2,166,955 bytes of the ZIP archive.\\
+Throughout the '90s, bandwidth steadily improved. Upon \doom{}'s release most modems were capable of 14.4 Kbit/s. Those who downloaded the shareware version in December 1993 had to wait 25 minutes to retrieve the 2,166,955 bytes of the ZIP archive.\\
 \par
 
  \begin{figure}[H]


### PR DESCRIPTION
[According to Wikipedia](https://en.wikipedia.org/wiki/Modem#Breaking_the_9.6_kbit/s_barrier), V.34 was not ratified until 1994, while Doom was released December 1993. Most people would probably have therefore had V.32bis modems (14.4kbit/sec) which matches the list of modems found in modem.str.

Accordingly double the download time since on 14.4kbit/sec it would have taken twice as long.