### PR TITLE
Script fixup, README update, cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,18 +2,19 @@ research
 xcshareddata
 DerivedData
 xcuserdata
-output\*
 .texpadtmp
 .DS_Store
+
+# IDE configuration
+/.idea/
+*.iml
+
+# Compilation product and byproducts
+/build/
+/output/
+*.o
 *.pdf
-*.aux
-*.log
-*.lot
-*.out
-*.toc
-**/*.o
-**/.idea
-**/*.WAD
+*.WAD
 cmake-build-debug
 CMakeFiles
 cmake-fab

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Game Engine Black Book: Doom
+# Game Engine Black Book: Doom
 
 This is the source code for the Game Engine Black Book: Doom.
 I am releasing the source code (.tex) under GPL license. I
@@ -6,11 +6,14 @@ retain ownership of all drawings and only provide them so the
 overall thing is compilable.
 
 To compile:
- - Install mactex library (for pdflatex)
- - Install Inkscape
- - run ./make.sh
+ - Install MacTeX library (for epstopdf and pdflatex):
+    - via installer: https://tug.org/mactex/mactex-download.html
+    - or via Homebrew, with GUI:    `brew cask install mactex`
+    - or via Homebrew, without GUI: `brew cask install mactex-no-gui`
+ - Install Inkscape: https://inkscape.org/download/
+ - Run: `./make.sh`
 
-Note this has only been tested on MacOS X. You will need to adjust the
+__Note:__ this has only been tested on Mac OS X. You will need to adjust the
 build script a little bit and probably fix case-sensitive path on Linux
 but I believe it should work with minimal work.
 
@@ -23,4 +26,4 @@ To speed up compilation:
   
 The PDF version looks nicer when cover.tex is included in src/book.tex.
 
-- Fabien Sanglard
+_Fabien Sanglard_

--- a/README.md
+++ b/README.md
@@ -5,20 +5,22 @@ I am releasing the source code (.tex) under GPL license. I
 retain ownership of all drawings and only provide them so the
 overall thing is compilable.
 
-To compile:
+To compile on Mac OS X:
+ - Install Inkscape:
+    - via installer: https://inkscape.org/download/
+    - or via Homebrew: `brew cask install xquartz inkscape`
  - Install MacTeX library (for epstopdf and pdflatex):
     - via installer: https://tug.org/mactex/mactex-download.html
     - or via Homebrew, with GUI:    `brew cask install mactex`
     - or via Homebrew, without GUI: `brew cask install mactex-no-gui`
- - Install Inkscape: https://inkscape.org/download/
- - Run: `./make.sh`
+ - Run:
+    - `./make.sh`
 
-__Note:__ this has only been tested on Mac OS X. You will need to adjust the
-build script a little bit and probably fix case-sensitive path on Linux
-but I believe it should work with minimal work.
-
-Debian GNU/Linux dependencies:
- - `sudo apt install inkscape texlive texlive-font-utils texlive-latex-extra`
+To compile on Debian GNU/Linux and derivatives (Ubuntu):
+ - Install Inkscape and TeX Live library (for epstopdf and pdflatex):
+    - `sudo apt install inkscape texlive texlive-font-utils texlive-latex-extra`
+ - Run:
+    - `./make.sh`
 
 To speed up compilation:
  - Use 100 DPI commands in src/mystyle.sty

--- a/make.sh
+++ b/make.sh
@@ -13,6 +13,10 @@ die() { rc=$1 && shift && for message in "$@"; do cat <<< "ERROR - $message" >&2
 [[ -x "$(command -v epstopdf)" ]] || die 11 "epstopdf command is unavailable" # MacTeX/TeX Live
 [[ -x "$(command -v pdflatex)" ]] || die 12 "pdflatex command is unavailable" # MacTeX/TeX Live
 
+# Check Inkscape version and choose export option accordingly (--export-png up to 0.92.x, --export-file from 1.x onwards)
+#	falls back on --export-png if unable to read version
+[[ $(inkscape --version | awk -F '[ .]' '{ print $2 }') -gt 0 ]] && exportOption="--export-file" || exportOption="--export-png"
+
 # epsToPDF - Convert EPS to PDF
 epsToPDF() {
 	# Build path without extension
@@ -45,7 +49,7 @@ svgToPNG() {
 	# -nt = newer than, -ot = older than
 	if [[ "$src" -nt "$dst" ]]; then
 		echo "Convert $extensionless.svg to PNG (100dpi)."
-		inkscape --export-png="$dst" --without-gui --export-dpi=100 "$src" > /dev/null 2>&1
+		inkscape $exportOption="$dst" --without-gui --export-dpi=100 "$src" > /dev/null 2>&1
 	fi
 
 	# High RES assets
@@ -53,7 +57,7 @@ svgToPNG() {
 	# -nt = newer than, -ot = older than
 	if [[ "$src" -nt "$dst" ]]; then
 		echo "Convert $extensionless.svg to PNG (300dpi)."
-		inkscape --export-png="$dst" --without-gui --export-dpi=300 "$src" > /dev/null 2>&1
+		inkscape $exportOption="$dst" --without-gui --export-dpi=300 "$src" > /dev/null 2>&1
 	fi
 }
 


### PR DESCRIPTION
_(Second pull request whatsoever, sorry for any mistake)_

Fix up and update:
- make.sh script fixup (error in variable name) and improvements (double quote variables to prevent word splitting, etc.)
- README update after tests on Mac OS X (10.14.6) and Linux (Ubuntu 19.10)

Cleanup:
- build directories added to .gitignore
- drawings converted from SVG deleted from source and added to .gitignore

I'm not sure you want to delete drawings converted from SVG (do you need them for others build without conversion step?).
I'm aware the diff for make.sh is not easily readable. I can cut the commit in parts if needed/preferred.

Thanks again for your blog and books, and especially for your blog posts on Another World (first on its VM-like engine, then on its different ports).
_Deluxe_