### PR TITLE
Cut support to Inkscape versions older than 1.x

### DIFF
--- a/make.sh
+++ b/make.sh
@@ -13,9 +13,8 @@ die() { rc=$1 && shift && for message in "$@"; do cat <<< "ERROR - $message" >&2
 [[ -x "$(command -v epstopdf)" ]] || die 11 "epstopdf command is unavailable" # MacTeX/TeX Live
 [[ -x "$(command -v pdflatex)" ]] || die 12 "pdflatex command is unavailable" # MacTeX/TeX Live
 
-# Check Inkscape version and choose export option accordingly (--export-png up to 0.92.x, --export-file from 1.x onwards)
-#	falls back on --export-png if unable to read version
-[[ $(inkscape --version | awk -F '[ .]' '{ print $2 }') -gt 0 ]] && exportOption="--export-file" || exportOption="--export-png"
+# Check Inkscape version (1.x minimum)
+[[ $(inkscape --version 2> /dev/null | awk -F '[ .]' '{ print $2 }') -gt 0 ]] || die 13 "inkscape is only supported from version 1.x onwards"
 
 # epsToPDF - Convert EPS to PDF
 epsToPDF() {
@@ -49,7 +48,7 @@ svgToPNG() {
 	# -nt = newer than, -ot = older than
 	if [[ "$src" -nt "$dst" ]]; then
 		echo "Convert $extensionless.svg to PNG (100dpi)."
-		inkscape $exportOption="$dst" --without-gui --export-dpi=100 "$src" > /dev/null 2>&1
+		inkscape --export-filename="$dst" --export-dpi=100 "$src" > /dev/null 2>&1
 	fi
 
 	# High RES assets
@@ -57,7 +56,7 @@ svgToPNG() {
 	# -nt = newer than, -ot = older than
 	if [[ "$src" -nt "$dst" ]]; then
 		echo "Convert $extensionless.svg to PNG (300dpi)."
-		inkscape $exportOption="$dst" --without-gui --export-dpi=300 "$src" > /dev/null 2>&1
+		inkscape --export-filename="$dst" --export-dpi=300 "$src" > /dev/null 2>&1
 	fi
 }
 


### PR DESCRIPTION
Tested on macOS 10.14.6 and Ubuntu 20.10.

Kept PATH alteration for 0.92.x on Mac, so old versions may not try to start their GUI (aka Contents/MacOS/Inkscape) but instead report correctly "inkscape is only supported from version 1.x onwards".