### PR TITLE
fix: Spelling of "Star Fox" in port_snex.tex

### DIFF
--- a/src/port_snes.tex
+++ b/src/port_snes.tex
@@ -72,11 +72,11 @@ The divorce was finalized when Nintendo refused to let Argonaut use Yoshi for a 
 \fullimage{snes_cartridge.png}
 \par
 \vspace{20pt}
-The MARIO chip had a simple design based on a 16-bit RISC processor running at 10.74 MHz with a 512 byte i-cache. It had its own instruction set optimized for math and its own framebuffer optimized for pixel plotting. Its mode of operation was to render to the frame buffer where the data would be periodically transfered to the SNES RAM via DMA. It was reportedly capable of rendering 76,458 polygons/s which meant about 15 fps for Starfox.\\
+The MARIO chip had a simple design based on a 16-bit RISC processor running at 10.74 MHz with a 512 byte i-cache. It had its own instruction set optimized for math and its own framebuffer optimized for pixel plotting. Its mode of operation was to render to the frame buffer where the data would be periodically transfered to the SNES RAM via DMA. It was reportedly capable of rendering 76,458 polygons/s which meant about 15 fps for Star Fox.\\
 
 
 \par
-Upon witnessing Starfox's phenomenal success, other studios became interested in the technology. The chip was revised to be able to run at 21.4 Mhz and it was renamed "GSU"\footnote{Graphics Support Unit}. The first generation of GSUs powered four games: Dirt Racer, Dirt Trax FX, Stunt Race FX, and Vortex.\\
+Upon witnessing Star Fox's phenomenal success, other studios became interested in the technology. The chip was revised to be able to run at 21.4 Mhz and it was renamed "GSU"\footnote{Graphics Support Unit}. The first generation of GSUs powered four games: Dirt Racer, Dirt Trax FX, Stunt Race FX, and Vortex.\\
 \par
  The second generation (GSU-2) was the same processor running at 21.4 Mhz with extra pins soldered to the bus to increase the size of supported ROM and framebuffer. It was used in three games: \doom{}, Super Mario World 2: Yoshi's Island, and Winter Gold.\\
 \par


### PR DESCRIPTION
- Fixed two instances of "Star Fox" being spelled in one word as "Starfox". Correct spelling seems to be in two words (https://en.wikipedia.org/wiki/Star_Fox).