### PR TITLE
[TASK] Build with younger inkscape

### DIFF
--- a/build.go
+++ b/build.go
@@ -104,7 +104,7 @@ func convertSVGtoPNG(folder string) {
 				if isOlder(dst, src) {
 					continue
 				}
-				cmd := inkscapeBin + ` --export-filename=` + dst + ` --export-dpi=` + dpis[i] + ` ` + src
+				cmd := inkscapeBin + ` --export-png=` + dst + ` --export-dpi=` + dpis[i] + ` ` + src
 				run(cmd)
 			}
 		}
@@ -129,9 +129,8 @@ func makeCover(src string, dst string) {
 
 	bin := inkscapeBin
 	args := make([]string, 0)
-	args = append(args, "--export-filename="+dst)
+	args = append(args, "--export-pdf="+dst)
 	args = append(args, "--export-dpi=300")
-	args = append(args, "--export-type=pdf")
 	args = append(args, "--export-text-to-path")
 	args = append(args, src)
 


### PR DESCRIPTION
Inkscape 0.92.5 (2060ec1f9f, 2020-04-08)

It seems recent inkscape dropped support for
--export-filename in favor of more specific
--export-<type>:

Invalid option --export-filename=/.../out/cover/back.pdf

The patch adapts build.go to deal with this.

This is just a "works on my machine", though:
It would probably be better to adapt the build
chain to properly deal with different inkscape
versions.