### PR TITLE
software_performances, acknowledgements: use "their" for Foone

### DIFF
--- a/src/acknowledgment.tex
+++ b/src/acknowledgment.tex
@@ -9,7 +9,7 @@ concernedly close.\\
 \par
 To Jim Leonard who once again volunteered his time and encyclopedic knowledge of audio hardware and software (the Roland section was heavily based on his articles).\\
 \par
-To Foone Turing who volunteered his fleet of 386s, 486s, and ISA/VLB VGA cards to accurately benchmark \doom{}.\\
+To Foone Turing who volunteered their fleet of 386s, 486s, and ISA/VLB VGA cards to accurately benchmark \doom{}.\\
 \par
 To Andrew Stine, founder of \cw{doomworld.com}, for sharing his encyclopedic knowledge of \doom{} and putting me in touch with the right people.\\
 \par

--- a/src/software_performances.tex
+++ b/src/software_performances.tex
@@ -25,7 +25,7 @@ The first value, \cw{gametics}, is the number of game tics rendered. For \cw{dem
  
 In the previous example\footnote{Benchmark machine was a miniPC Unisys CWD 4001 (486DX2-66/CirrusLogic-GD5424).}, the game ran at an average of $\frac{2134}{4268}*35 = 17.5$ fps. \\
 \par
-This mechanism allows running benchmarks across varying configurations. Since machines from 1994 have become difficult to come by these days, a generous collector named Foone Turing kindly volunteered his impressive fleet of machines. The results of the archaeological-benchmarking session are visible in figure \ref{bnechmarsks}.\\
+This mechanism allows running benchmarks across varying configurations. Since machines from 1994 have become difficult to come by these days, a generous collector named Foone Turing kindly volunteered their impressive fleet of machines. The results of the archaeological-benchmarking session are visible in figure \ref{bnechmarsks}.\\
 \par
  The results of the session demonstrate that none of the hardware of the time was able to max out the game. Remember that beyond 35fps there would be no visual improvement since the game logic is hard-coded to run at 35Hz. A machine able to render 70fps video/audio would render the same game frame twice.\\
 \par


### PR DESCRIPTION
Just a small change reflecting their public profile. Foone Turing's machines should be referred to as singular "their" machines in publication.

Resolves #66.